### PR TITLE
Support for Harmony response format

### DIFF
--- a/src/components/MessageBox.tsx
+++ b/src/components/MessageBox.tsx
@@ -52,9 +52,9 @@ const MessageBox = ({
     const regex = /\[(\d+)\]/g;
     let processedMessage = message.content;
 
-    if (message.role === 'assistant' && message.content.includes('<think>')) {
-      const openThinkTag = processedMessage.match(/<think>/g)?.length || 0;
-      const closeThinkTag = processedMessage.match(/<\/think>/g)?.length || 0;
+    if (message.role === 'assistant' && /<(think|details[^>]*)>/g.test(message.content)) {
+      const openThinkTag = processedMessage.match(/<(think|details[^>]*)>/g)?.length || 0;
+      const closeThinkTag = processedMessage.match(/<\/(think|details)>/g)?.length || 0;
 
       if (openThinkTag > closeThinkTag) {
         processedMessage += '</think> <a> </a>'; // The extra <a> </a> is to prevent the the think component from looking bad

--- a/src/lib/search/metaSearchAgent.ts
+++ b/src/lib/search/metaSearchAgent.ts
@@ -203,7 +203,7 @@ class MetaSearchAgent implements MetaSearchAgentType {
 
           return { query: question, docs: docs };
         } else {
-          question = question.replace(/<think>.*?<\/think>/g, '');
+          question = question.replace(/<think>.*?<\/think>/g, '').replace(/<details[^>]*>.*?<\/details>/g, '');
 
           const res = await searchSearxng(question, {
             language: 'en',


### PR DESCRIPTION
Updated MessageBox to support both `<think>` and `<details>` tags for assistant messages, ensuring proper tag closure. Also updated metaSearchAgent to strip both `<think>` and `<details>` blocks from questions before search, adding support for OpenAI Harmony response format.